### PR TITLE
Use head instead of get

### DIFF
--- a/lib/custom_ping.dart
+++ b/lib/custom_ping.dart
@@ -64,7 +64,7 @@ class PingService {
     try {
       Uri url = Uri.parse(urlTarget);
 
-      Response response = await _httpClient.get(url).timeout(timeout, onTimeout: () {
+      Response response = await _httpClient.head(url).timeout(timeout, onTimeout: () {
         throw ReachServerFailException();
       });
 


### PR DESCRIPTION
In theory, if you just get the headers, the request could be faster and use less data.

You are truly not interested in the content of the request, but just see if it answers.

WDYT?